### PR TITLE
dependency fix docker build/run

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 bcrypt==3.1
 blinker==1.3
 Cerberus==0.8.1
-cffi==0.9.2
+cffi==1.1
 Eve==0.5.3
 Eve-docs==0.1.4
 Events==0.2.1


### PR DESCRIPTION
bcrypt 3.1.0 has requirement cffi>=1.1, but you'll have cffi 0.9.2 which is incompatible.